### PR TITLE
Add Kraken ledger CSV import

### DIFF
--- a/src/FIFOCalculator.Engine/Kraken/LedgerCsvParser.cs
+++ b/src/FIFOCalculator.Engine/Kraken/LedgerCsvParser.cs
@@ -1,0 +1,139 @@
+using System.Globalization;
+
+namespace FIFOCalculator.Engine.Kraken;
+
+public static class LedgerCsvParser
+{
+    private static readonly string[] TradeLikeTypes = ["trade", "spend", "receive"];
+
+    public static IReadOnlyList<LedgerEntry> ParseCsv(TextReader reader)
+    {
+        var entries = new List<LedgerEntry>();
+        var header = reader.ReadLine();
+        if (header == null) return entries;
+
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            var entry = ParseLine(line);
+            entries.Add(entry);
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// Converts Kraken ledger entries into FIFO entries for a given asset pair.
+    /// </summary>
+    /// <param name="ledger">Parsed ledger entries from <see cref="ParseCsv"/>.</param>
+    /// <param name="targetAsset">The asset to track (e.g., "BTC").</param>
+    /// <param name="quoteAsset">The quote/fiat currency (e.g., "EUR").</param>
+    /// <param name="depositCostBasisProvider">
+    /// Optional callback to provide the cost basis (price per unit in quote currency)
+    /// for deposits of the target asset. When provided, deposits are included as buy entries.
+    /// When null, deposits are ignored.
+    /// </param>
+    public static IReadOnlyList<Entry> ToFifoEntries(
+        IReadOnlyList<LedgerEntry> ledger,
+        string targetAsset,
+        string quoteAsset = "EUR",
+        Func<LedgerEntry, decimal>? depositCostBasisProvider = null)
+    {
+        var results = new List<Entry>();
+
+        // Handle trade/spend/receive pairs
+        var paired = ledger
+            .Where(e => TradeLikeTypes.Contains(e.Type))
+            .GroupBy(e => e.RefId)
+            .Where(g => g.Count() == 2);
+
+        foreach (var group in paired)
+        {
+            var legs = group.ToArray();
+            var targetLeg = legs.FirstOrDefault(l => NormalizeAsset(l.Asset) == targetAsset);
+            var quoteLeg = legs.FirstOrDefault(l => NormalizeAsset(l.Asset) == quoteAsset);
+
+            if (targetLeg == null || quoteLeg == null) continue;
+
+            var units = Math.Abs(targetLeg.Amount);
+            if (units == 0) continue;
+
+            var quoteAmount = Math.Abs(quoteLeg.Amount);
+            var totalFees = quoteLeg.Fee + targetLeg.Fee * (quoteAmount / units);
+
+            decimal pricePerUnit;
+            decimal signedUnits;
+
+            if (targetLeg.Amount > 0)
+            {
+                pricePerUnit = (quoteAmount + totalFees) / units;
+                signedUnits = units;
+            }
+            else
+            {
+                pricePerUnit = (quoteAmount - totalFees) / units;
+                signedUnits = -units;
+            }
+
+            results.Add(new Entry(targetLeg.Time, signedUnits, pricePerUnit));
+        }
+
+        // Handle deposits as buys (when a cost basis provider is given)
+        if (depositCostBasisProvider != null)
+        {
+            var deposits = ledger
+                .Where(e => e.Type == "deposit" && NormalizeAsset(e.Asset) == targetAsset && e.Amount > 0);
+
+            foreach (var deposit in deposits)
+            {
+                var costBasis = depositCostBasisProvider(deposit);
+                results.Add(new Entry(deposit.Time, deposit.Amount, costBasis));
+            }
+        }
+
+        return results.OrderBy(e => e.When).ToList();
+    }
+
+    private static string NormalizeAsset(string asset) =>
+        asset.Replace(".HOLD", "").Replace(".S", "");
+
+    private static LedgerEntry ParseLine(string line)
+    {
+        var fields = SplitCsvLine(line);
+
+        return new LedgerEntry(
+            TxId: Unquote(fields[0]),
+            RefId: Unquote(fields[1]),
+            Time: DateTimeOffset.Parse(Unquote(fields[2]), CultureInfo.InvariantCulture),
+            Type: Unquote(fields[3]),
+            Subtype: Unquote(fields[4]),
+            Asset: Unquote(fields[7]),
+            Amount: decimal.Parse(Unquote(fields[9]), CultureInfo.InvariantCulture),
+            Fee: decimal.Parse(Unquote(fields[10]), CultureInfo.InvariantCulture),
+            Balance: decimal.Parse(Unquote(fields[11]), CultureInfo.InvariantCulture));
+    }
+
+    private static string Unquote(string s) =>
+        s.Length >= 2 && s[0] == '"' && s[^1] == '"' ? s[1..^1] : s;
+
+    private static string[] SplitCsvLine(string line)
+    {
+        var fields = new List<string>();
+        var inQuotes = false;
+        var start = 0;
+
+        for (var i = 0; i < line.Length; i++)
+        {
+            if (line[i] == '"') inQuotes = !inQuotes;
+            if (line[i] == ',' && !inQuotes)
+            {
+                fields.Add(line[start..i]);
+                start = i + 1;
+            }
+        }
+
+        fields.Add(line[start..]);
+        return fields.ToArray();
+    }
+}

--- a/src/FIFOCalculator.Engine/Kraken/LedgerEntry.cs
+++ b/src/FIFOCalculator.Engine/Kraken/LedgerEntry.cs
@@ -1,0 +1,12 @@
+namespace FIFOCalculator.Engine.Kraken;
+
+public record LedgerEntry(
+    string TxId,
+    string RefId,
+    DateTimeOffset Time,
+    string Type,
+    string Subtype,
+    string Asset,
+    decimal Amount,
+    decimal Fee,
+    decimal Balance);

--- a/tests/KrakenLedgerParserTests.cs
+++ b/tests/KrakenLedgerParserTests.cs
@@ -1,0 +1,223 @@
+using FIFOCalculator.Engine;
+using FIFOCalculator.Engine.Kraken;
+
+namespace TestProject1;
+
+public class KrakenLedgerParserTests
+{
+    private const string SampleCsv = """
+        "txid","refid","time","type","subtype","aclass","subclass","asset","wallet","amount","fee","balance"
+        "TX1","REF1","2023-01-10 10:00:00","trade","tradespot","currency","fiat","EUR","spot / main",-500.0000,1.5000,0.0000
+        "TX2","REF1","2023-01-10 10:00:00","trade","tradespot","currency","crypto","BTC","spot / main",0.0250000000,0,0.0250000000
+        "TX3","REF2","2023-06-15 14:00:00","trade","tradespot","currency","crypto","BTC","spot / main",-0.0100000000,0,0.0150000000
+        "TX4","REF2","2023-06-15 14:00:00","trade","tradespot","currency","fiat","EUR","spot / main",300.0000,0.9000,299.1000
+        """;
+
+    [Fact]
+    public void ParseCsv_returns_all_entries()
+    {
+        using var reader = new StringReader(SampleCsv);
+        var entries = LedgerCsvParser.ParseCsv(reader);
+        entries.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void ParseCsv_parses_fields_correctly()
+    {
+        using var reader = new StringReader(SampleCsv);
+        var entries = LedgerCsvParser.ParseCsv(reader);
+
+        var btcBuy = entries.First(e => e.TxId == "TX2");
+        btcBuy.RefId.Should().Be("REF1");
+        btcBuy.Type.Should().Be("trade");
+        btcBuy.Asset.Should().Be("BTC");
+        btcBuy.Amount.Should().Be(0.025m);
+        btcBuy.Fee.Should().Be(0m);
+    }
+
+    [Fact]
+    public void ToFifoEntries_buy_includes_fees_in_cost_basis()
+    {
+        using var reader = new StringReader(SampleCsv);
+        var ledger = LedgerCsvParser.ParseCsv(reader);
+        var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC");
+
+        var buy = entries.First(e => e.Units > 0);
+
+        buy.Units.Should().Be(0.025m);
+        // Cost basis = (500 + 1.50 fee) / 0.025 = 20,060
+        buy.PricePerUnit.Should().Be((500m + 1.5m) / 0.025m);
+    }
+
+    [Fact]
+    public void ToFifoEntries_sell_subtracts_fees_from_proceeds()
+    {
+        using var reader = new StringReader(SampleCsv);
+        var ledger = LedgerCsvParser.ParseCsv(reader);
+        var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC");
+
+        var sell = entries.First(e => e.Units < 0);
+
+        sell.Units.Should().Be(-0.01m);
+        // Net proceeds = (300 - 0.90 fee) / 0.01 = 29,910
+        sell.PricePerUnit.Should().Be((300m - 0.9m) / 0.01m);
+    }
+
+    [Fact]
+    public void ToFifoEntries_returns_sorted_by_date()
+    {
+        using var reader = new StringReader(SampleCsv);
+        var ledger = LedgerCsvParser.ParseCsv(reader);
+        var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC");
+
+        entries.Should().HaveCount(2);
+        entries[0].Units.Should().BePositive(); // buy first (Jan)
+        entries[1].Units.Should().BeNegative(); // sell second (Jun)
+    }
+
+    [Fact]
+    public void ToFifoEntries_ignores_unrelated_assets()
+    {
+        const string csv = """
+            "txid","refid","time","type","subtype","aclass","subclass","asset","wallet","amount","fee","balance"
+            "TX1","REF1","2023-01-10 10:00:00","trade","tradespot","currency","fiat","EUR","spot / main",-100.0000,0.5000,0.0000
+            "TX2","REF1","2023-01-10 10:00:00","trade","tradespot","currency","crypto","ETH","spot / main",0.0500000000,0,0.0500000000
+            """;
+
+        using var reader = new StringReader(csv);
+        var ledger = LedgerCsvParser.ParseCsv(reader);
+        var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC");
+
+        entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToFifoEntries_handles_spend_receive_pairs()
+    {
+        const string csv = """
+            "txid","refid","time","type","subtype","aclass","subclass","asset","wallet","amount","fee","balance"
+            "TX1","REF1","2022-03-07 22:02:00","spend","","currency","hold","EUR.HOLD","spot / main",-47.1600,0.7100,0.0000
+            "TX2","REF1","2022-03-07 22:02:00","receive","","currency","crypto","BTC","spot / main",0.0013534800,0,0.0013534800
+            """;
+
+        using var reader = new StringReader(csv);
+        var ledger = LedgerCsvParser.ParseCsv(reader);
+        var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC");
+
+        entries.Should().HaveCount(1);
+        var buy = entries[0];
+        buy.Units.Should().Be(0.0013534800m);
+        // Cost = (47.16 + 0.71) / 0.0013534800
+        buy.PricePerUnit.Should().Be((47.16m + 0.71m) / 0.0013534800m);
+    }
+
+    [Fact]
+    public void ToFifoEntries_normalizes_hold_asset_names()
+    {
+        const string csv = """
+            "txid","refid","time","type","subtype","aclass","subclass","asset","wallet","amount","fee","balance"
+            "TX1","REF1","2022-03-07 22:02:00","spend","","currency","hold","EUR.HOLD","spot / main",-50.0000,0.0000,0.0000
+            "TX2","REF1","2022-03-07 22:02:00","receive","","currency","crypto","BTC","spot / main",0.0010000000,0,0.0010000000
+            """;
+
+        using var reader = new StringReader(csv);
+        var ledger = LedgerCsvParser.ParseCsv(reader);
+        // EUR.HOLD should match "EUR"
+        var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC", "EUR");
+
+        entries.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void ToFifoEntries_ignores_deposits_by_default()
+    {
+        const string csv = """
+            "txid","refid","time","type","subtype","aclass","subclass","asset","wallet","amount","fee","balance"
+            "TX1","REF1","2022-03-07 22:01:59","deposit","","currency","hold","EUR.HOLD","spot / main",50.0000,2.1300,47.8700
+            "TX2","REF2","2023-05-01 10:00:00","withdrawal","","currency","crypto","BTC","spot / main",-0.5000000000,0.0001,0.0000000000
+            "TX3","REF3","2022-03-25 08:47:20","deposit","","currency","crypto","BTC","spot / main",0.1449503300,0,0.1449503300
+            """;
+
+        using var reader = new StringReader(csv);
+        var ledger = LedgerCsvParser.ParseCsv(reader);
+        var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC");
+
+        entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToFifoEntries_includes_deposits_with_cost_basis_provider()
+    {
+        const string csv = """
+            "txid","refid","time","type","subtype","aclass","subclass","asset","wallet","amount","fee","balance"
+            "TX1","REF1","2022-03-25 08:47:20","deposit","","currency","crypto","BTC","spot / main",0.1449503300,0,0.1449503300
+            """;
+
+        using var reader = new StringReader(csv);
+        var ledger = LedgerCsvParser.ParseCsv(reader);
+        var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC",
+            depositCostBasisProvider: _ => 39668.76m);
+
+        entries.Should().HaveCount(1);
+        var buy = entries[0];
+        buy.Units.Should().Be(0.14495033m);
+        buy.PricePerUnit.Should().Be(39668.76m);
+    }
+
+    [Fact]
+    public void Deposits_with_provider_integrate_into_fifo()
+    {
+        const string csv = """
+            "txid","refid","time","type","subtype","aclass","subclass","asset","wallet","amount","fee","balance"
+            "TX1","REF1","2023-01-01 10:00:00","deposit","","currency","crypto","BTC","spot / main",1.0000000000,0,1.0000000000
+            "TX2","REF2","2023-06-01 10:00:00","trade","tradespot","currency","crypto","BTC","spot / main",-0.5000000000,0,0.5000000000
+            "TX3","REF2","2023-06-01 10:00:00","trade","tradespot","currency","fiat","EUR","spot / main",15000.0000,30.0000,14970.0000
+            """;
+
+        using var reader = new StringReader(csv);
+        var ledger = LedgerCsvParser.ParseCsv(reader);
+        var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC",
+            depositCostBasisProvider: _ => 20000m);
+
+        var calc = new BalanceCalculator();
+        var result = calc.Calculate(entries);
+
+        result.IsSuccess.Should().BeTrue();
+        // Buy 1 BTC at 20000, sell 0.5 at (15000-30)/0.5 = 29940
+        // Gain = 0.5 * (29940 - 20000) = 4970
+        result.Value.GainOrLoss.Should().Be(0.5m * (29940m - 20000m));
+        result.Value.RemainingInventoryValue.Should().Be(0.5m * 20000m);
+    }
+
+    [Fact]
+    public void Full_pipeline_with_calculator()
+    {
+        const string csv = """
+            "txid","refid","time","type","subtype","aclass","subclass","asset","wallet","amount","fee","balance"
+            "TX1","REF1","2023-01-10 10:00:00","trade","tradespot","currency","fiat","EUR","spot / main",-1000.0000,2.0000,0.0000
+            "TX2","REF1","2023-01-10 10:00:00","trade","tradespot","currency","crypto","BTC","spot / main",0.0500000000,0,0.0500000000
+            "TX3","REF2","2023-06-15 14:00:00","trade","tradespot","currency","crypto","BTC","spot / main",-0.0300000000,0,0.0200000000
+            "TX4","REF2","2023-06-15 14:00:00","trade","tradespot","currency","fiat","EUR","spot / main",900.0000,1.5000,898.5000
+            """;
+
+        using var reader = new StringReader(csv);
+        var ledger = LedgerCsvParser.ParseCsv(reader);
+        var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC");
+
+        var calculator = new BalanceCalculator();
+        var result = calculator.Calculate(entries);
+
+        result.IsSuccess.Should().BeTrue();
+
+        // Buy: 0.05 BTC at (1000+2)/0.05 = 20,040 EUR/BTC
+        // Sell: 0.03 BTC at (900-1.5)/0.03 = 29,950 EUR/BTC
+        // Gain = 0.03 * (29950 - 20040) = 297.30
+        var expectedBuyPrice = (1000m + 2m) / 0.05m;
+        var expectedSellPrice = (900m - 1.5m) / 0.03m;
+        var expectedGain = 0.03m * (expectedSellPrice - expectedBuyPrice);
+
+        result.Value.GainOrLoss.Should().Be(expectedGain);
+        // Remaining: 0.02 BTC at 20,040
+        result.Value.RemainingInventoryValue.Should().Be(0.02m * expectedBuyPrice);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Kraken ledger CSV parser to `FIFOCalculator.Engine` so users can import their Kraken export directly and calculate FIFO balances.

## Usage

```csharp
using var reader = new StreamReader("kraken_ledgers.csv");
var ledger = LedgerCsvParser.ParseCsv(reader);

var entries = LedgerCsvParser.ToFifoEntries(ledger, "BTC", "EUR",
    depositCostBasisProvider: deposit => lookupOriginalPrice(deposit.Time));

var result = new BalanceCalculator().Calculate(entries);
```

## Details

- Parses Kraken `stocks_etfs_ledgers` CSV format (`txid`, `refid`, `time`, `type`, `asset`, `amount`, `fee`, `balance`)
- Groups `trade` and `spend`/`receive` entries by `refid` to pair buy/sell legs
- Calculates effective price per unit including fees (fees increase cost basis on buys, reduce proceeds on sells)
- Handles `EUR.HOLD` → `EUR` asset name normalization
- **Deposits**: optional `depositCostBasisProvider` callback to include crypto deposits as buys with an externally-provided cost basis (for BTC bought on other platforms and transferred to Kraken)
- 12 new tests covering CSV parsing, fee accounting, deposit handling, and full pipeline integration

## Verified

Tested against a real Kraken ledger export (383 entries, 162 BTC operations) — full pipeline runs successfully.