### PR TITLE
feat!: Migrate to Avalonia 12 and Optris icons

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<AvaloniaVersion>11.3.13</AvaloniaVersion>
+		<AvaloniaVersion>12.0.0</AvaloniaVersion>
 	</PropertyGroup>
 </Project>

--- a/src/FIFOCalculator.Desktop/FIFOCalculator.Desktop.csproj
+++ b/src/FIFOCalculator.Desktop/FIFOCalculator.Desktop.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-		<PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
+		<PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0-beta3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/FIFOCalculator/App.axaml
+++ b/src/FIFOCalculator/App.axaml
@@ -12,7 +12,6 @@
 
     <Application.Styles>
         <FluentTheme />
-        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
         <StyleInclude Source="avares://Zafiro.Avalonia/Styles.axaml"/>
         <StyleInclude Source="Controls/SvgButton.axaml"/>
 

--- a/src/FIFOCalculator/App.axaml.cs
+++ b/src/FIFOCalculator/App.axaml.cs
@@ -4,6 +4,8 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using FIFOCalculator.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using Optris.Icons.Avalonia;
+using Optris.Icons.Avalonia.FontAwesome;
 using Serilog;
 using Zafiro.Avalonia.Controls.Shell;
 using Zafiro.Avalonia.Icons;
@@ -24,7 +26,8 @@ public partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
-        IconControlProviderRegistry.Register(new ProjektankerIconControlProvider(), asDefault: true);
+        IconProvider.Current.Register<FontAwesomeIconProvider>();
+        IconControlProviderRegistry.Register(new OptrisIconControlProvider(), asDefault: true);
 
         var dynamicDataSink = new DynamicDataSink();
         Log.Logger = new LoggerConfiguration()
@@ -48,7 +51,7 @@ public partial class App : Application
                     // Resolve StorageProvider from the main window via ApplicationLifetime.
                     // TopLevel.GetTopLevel(view) is null here because the view isn't attached yet.
                     var desktop = (IClassicDesktopStyleApplicationLifetime)ApplicationLifetime!;
-                    return new AvaloniaFileSystemPicker(desktop.MainWindow!.StorageProvider);
+                    return new AvaloniaFileSystemPicker(() => desktop.MainWindow!.StorageProvider);
                 });
 
                 var provider = services.BuildServiceProvider();

--- a/src/FIFOCalculator/FIFOCalculator.csproj
+++ b/src/FIFOCalculator/FIFOCalculator.csproj
@@ -17,30 +17,30 @@
 
 	<ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Svg" Version="11.3.0" />
+    <PackageReference Include="Svg.Controls.Skia.Avalonia" Version="12.0.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8" />
-    <PackageReference Include="ProDataGrid" Version="11.3.11" />
+    <PackageReference Include="ReactiveUI.Avalonia" Version="11.3.8" />
+    <PackageReference Include="ProDataGrid" Version="12.0.0" />
     <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.6.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.9.5" />
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0" />
     <PackageReference Include="CSharpFunctionalExtensions" Version="3.6.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="ReactiveUI.Validation" Version="6.0.5" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="Zafiro.Avalonia" Version="51.2.0" />
-    <PackageReference Include="Zafiro.Avalonia.Generators" Version="51.2.0">
+    <PackageReference Include="Zafiro.Avalonia" Version="51.3.0" />
+    <PackageReference Include="Zafiro.Avalonia.Generators" Version="51.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Zafiro.Avalonia.Icons.Projektanker" Version="51.2.0" />
+    <PackageReference Include="Optris.Icons.Avalonia" Version="12.0.4" />
+    <PackageReference Include="Optris.Icons.Avalonia.FontAwesome" Version="12.0.4" />
     <PackageReference Include="Zafiro.UI" Version="47.0.2" />
-    <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.6.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
   </ItemGroup>
 

--- a/src/FIFOCalculator/OptrisIconControlProvider.cs
+++ b/src/FIFOCalculator/OptrisIconControlProvider.cs
@@ -1,0 +1,28 @@
+using Avalonia.Controls;
+using Zafiro.Avalonia.Controls;
+using Zafiro.Avalonia.Icons;
+using OptrisIcon = Optris.Icons.Avalonia.Icon;
+
+namespace FIFOCalculator;
+
+/// <summary>
+/// Icon provider that renders <see cref="Zafiro.UI.IIcon"/> using Optris.Icons.Avalonia.Icon.
+/// Temporary local class until Zafiro.Avalonia.Icons.Optris is published on NuGet.
+/// </summary>
+public class OptrisIconControlProvider : IIconControlProvider
+{
+    public string Prefix => "optris";
+
+    public Control? Create(Zafiro.UI.IIcon icon, string valueWithoutPrefix)
+    {
+        var source = icon.Source;
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return null;
+        }
+
+        var optrisIcon = new OptrisIcon { Value = source };
+        optrisIcon[!OptrisIcon.ForegroundProperty] = optrisIcon[!IconOptions.FillProperty];
+        return optrisIcon;
+    }
+}

--- a/src/FIFOCalculator/ViewModels/LogViewModel.cs
+++ b/src/FIFOCalculator/ViewModels/LogViewModel.cs
@@ -3,7 +3,9 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input.Platform;
 using DynamicData;
 using ReactiveUI;
 using Zafiro.UI.Shell.Utils;
@@ -25,9 +27,14 @@ public partial class LogViewModel : ViewModelBase
 
         CopyLog = ReactiveCommand.CreateFromTask(async () =>
         {
-            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: { Clipboard: not null } window })
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: { } window })
             {
-                await window.Clipboard.SetTextAsync(string.Join(Environment.NewLine, logger.Events.Items.Select(x => x.RenderMessage())));
+                var clipboard = TopLevel.GetTopLevel(window)?.Clipboard;
+                if (clipboard is not null)
+                {
+                    var text = string.Join(Environment.NewLine, logger.Events.Items.Select(x => x.RenderMessage()));
+                    await clipboard.SetTextAsync(text);
+                }
             }
         });
     }

--- a/src/FIFOCalculator/Views/EntryEditorView.axaml
+++ b/src/FIFOCalculator/Views/EntryEditorView.axaml
@@ -45,7 +45,7 @@
                                  MinWidth="0"
                                  Foreground="{TemplateBinding Foreground}"
                                  FontSize="{TemplateBinding FontSize}"
-                                 Watermark="{TemplateBinding Watermark}"
+                                 PlaceholderText="{TemplateBinding Watermark}"
                                  IsReadOnly="{TemplateBinding IsReadOnly}"
                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"


### PR DESCRIPTION
## Breaking Changes

Migrates the project from Avalonia 11 to Avalonia 12 and replaces dissolved Projektanker packages with Optris fork.

### Package Changes
| Old | New | Version |
|---|---|---|
| Avalonia 11.3.13 | Avalonia 12.0.0 | 12.0.0 |
| Projektanker.Icons.Avalonia.FontAwesome | Optris.Icons.Avalonia.FontAwesome | 12.0.4 |
| Avalonia.Svg | Svg.Controls.Skia.Avalonia | 12.0.0 |
| Avalonia.ReactiveUI | ReactiveUI.Avalonia | 11.3.8 |
| ProDataGrid 11.x | ProDataGrid | 12.0.0 |
| Xaml.Behaviors.Avalonia 11.x | Xaml.Behaviors.Avalonia | 12.0.0 |
| Zafiro.Avalonia 51.2.x | Zafiro.Avalonia | 51.3.0 |

### Avalonia 12 API Fixes
- `IClipboard.SetTextAsync` → extension method in `Avalonia.Input.Platform`
- DataGrid `StyleInclude` removed (now built into FluentTheme)
- `TextBox.Watermark` → `PlaceholderText`
- `AvaloniaFileSystemPicker` constructor updated for `Func<IStorageProvider>` API
- `DiagnosticsSupport` updated to 2.2.0-beta3

### Notes
- Added local `OptrisIconControlProvider` (temporary until `Zafiro.Avalonia.Icons.Optris` is published to NuGet)
- All 35 tests pass ✅