### PR TITLE
feat: add fiscal year FIFO balance section

### DIFF
--- a/src/FIFOCalculator.Engine/BalanceCalculator.cs
+++ b/src/FIFOCalculator.Engine/BalanceCalculator.cs
@@ -38,4 +38,47 @@ public class BalanceCalculator
 
         return new Balance(gainOrLoss, store.InventoryValue);
     }
+
+    /// <summary>
+    /// Calculates the FIFO balance for a specific fiscal year.
+    /// Processes all entries from the beginning to build correct inventory state,
+    /// but only accumulates gain/loss from sells within the target year.
+    /// </summary>
+    public Result<Balance> CalculateForYear(IEnumerable<Entry> entries, int year)
+    {
+        var store = new FifoStore();
+        var gainOrLoss = 0m;
+
+        var yearStart = new DateTimeOffset(new DateTime(year, 1, 1), TimeSpan.Zero);
+        var yearEnd = new DateTimeOffset(new DateTime(year + 1, 1, 1), TimeSpan.Zero);
+
+        var sorted = entries
+            .OrderBy(e => e.When)
+            .Where(e => e.When < yearEnd);
+
+        foreach (var entry in sorted)
+        {
+            if (entry.Units > 0)
+            {
+                store.Buy(new Order(entry.Units, entry.PricePerUnit));
+            }
+            else if (entry.Units < 0)
+            {
+                var sellUnits = -entry.Units;
+                var result = store.Sell(sellUnits, entry.PricePerUnit);
+
+                if (result.IsFailure)
+                {
+                    return Result.Failure<Balance>(result.Error);
+                }
+
+                if (entry.When >= yearStart)
+                {
+                    gainOrLoss += result.Value;
+                }
+            }
+        }
+
+        return new Balance(gainOrLoss, store.InventoryValue);
+    }
 }

--- a/src/FIFOCalculator/Models/BalanceCalculator.cs
+++ b/src/FIFOCalculator/Models/BalanceCalculator.cs
@@ -61,4 +61,58 @@ public class BalanceCalculator
 
         return new Balance(balance, store.InventoryValue);
     }
+
+    public Result<Balance> CalculateForYear(IEnumerable<Entry> entries, int year)
+    {
+        var yearStart = new DateTime(year, 1, 1);
+        var yearEnd = new DateTime(year + 1, 1, 1);
+        var balance = 0m;
+
+        var sorted = entries.OrderBy(x => x.When).Where(x => x.When < yearEnd);
+
+        logger.Execute(x => x.Information("Calculando balance FIFO para el ejercicio {Year}", year));
+
+        foreach (var operation in sorted)
+        {
+            if (operation.Units > 0)
+            {
+                logger.Execute(x => x.Information("{Date:d}: Compra de {Value:C} ({Units} a {Price:C})", operation.When, operation.Units * operation.PricePerUnit, operation.Units, operation.PricePerUnit));
+                store.Buy(new Order(operation.Units, operation.PricePerUnit));
+            }
+            else
+            {
+                logger.Execute(x => x.Information("{Date:d}: Venta de {Value:C} ({Units} a {Price:C})", operation.When, -operation.Units * operation.PricePerUnit, -operation.Units, operation.PricePerUnit));
+                var result = store.Sell(-operation.Units, operation.PricePerUnit);
+
+                if (result.IsFailure)
+                {
+                    return Result.Failure<Balance>($"Couldn't calculate balance {result.Error}");
+                }
+
+                if (operation.When >= yearStart)
+                {
+                    balance += result.Value;
+                    logger.Execute(x =>
+                    {
+                        if (result.Value > 0)
+                        {
+                            x.Information("Hemos ganado {Gain:C}", result.Value);
+                        }
+                        else
+                        {
+                            x.Information("Hemos perdido {Loss:C}", -result.Value);
+                        }
+                    });
+                }
+                else
+                {
+                    logger.Execute(x => x.Information("  (Venta de ejercicio anterior, no se cuenta en el balance)"));
+                }
+            }
+        }
+
+        logger.Execute(x => x.Information("Balance del ejercicio {Year}: {Balance:C}", year, balance));
+
+        return new Balance(balance, store.InventoryValue);
+    }
 }

--- a/src/FIFOCalculator/ViewModels/FiscalYearViewModel.cs
+++ b/src/FIFOCalculator/ViewModels/FiscalYearViewModel.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using CSharpFunctionalExtensions;
+using FIFOCalculator.Models;
+using ReactiveUI;
+using ReactiveUI.SourceGenerators;
+using Zafiro.CSharpFunctionalExtensions;
+using Zafiro.UI;
+using Zafiro.UI.Shell.Utils;
+
+namespace FIFOCalculator.ViewModels;
+
+[Section(icon: "fa-calendar", sortIndex: 2, FriendlyName = "Fiscal Year")]
+public partial class FiscalYearViewModel : ViewModelBase
+{
+    private readonly ObservableAsPropertyHelper<IReadOnlyList<Entry>> entries;
+    private readonly ObservableAsPropertyHelper<IReadOnlyList<int>> availableYears;
+
+    public FiscalYearViewModel(DataEntryViewModel dataEntry, INotificationService notificationService)
+    {
+        var inputs = dataEntry.Inputs;
+        var outputs = dataEntry.Outputs;
+        var inputEntries = inputs.EntriesCollection
+            .Select(list => list.OrderBy(entry => entry.When).ToList())
+            .Publish()
+            .RefCount();
+
+        var outputEntries = outputs.EntriesCollection
+            .Select(list => list.OrderBy(entry => entry.When).ToList())
+            .Publish()
+            .RefCount();
+
+        entries = inputEntries
+            .CombineLatest(outputEntries, (ins, outs) => ins
+                .Concat(outs.Select(entry => entry with { Units = -entry.Units }))
+                .OrderBy(entry => entry.When)
+                .ToList())
+            .Select(list => (IReadOnlyList<Entry>)list)
+            .ToProperty(this, model => model.Entries, new List<Entry>());
+
+        availableYears = inputEntries
+            .CombineLatest(outputEntries, (ins, outs) => ins.Concat(outs))
+            .Select(list => (IReadOnlyList<int>)list
+                .Select(entry => entry.When.Year)
+                .Distinct()
+                .OrderBy(year => year)
+                .ToList())
+            .ToProperty(this, model => model.AvailableYears, new List<int>());
+
+        Calculate = ReactiveCommand.Create(() =>
+        {
+            var calculator = new BalanceCalculator(new Store(Maybe.From(Log.Logger)), Maybe.From(Log.Logger));
+            return calculator.CalculateForYear(Entries, SelectedYear!.Value);
+        }, this.WhenAnyValue(x => x.SelectedYear).Select(y => y.HasValue));
+
+        Result = Calculate.Successes();
+        Calculate.HandleErrorsWith(notificationService);
+
+        this.WhenAnyValue(model => model.SelectedYear)
+            .Where(year => year.HasValue)
+            .Select(_ => Unit.Default)
+            .InvokeCommand(Calculate);
+    }
+
+    [Reactive] private int? _selectedYear;
+
+    public IObservable<Balance> Result { get; }
+
+    public ReactiveCommand<Unit, Result<Balance>> Calculate { get; }
+
+    public IReadOnlyList<int> AvailableYears => availableYears.Value;
+
+    private IReadOnlyList<Entry> Entries => entries.Value;
+}

--- a/src/FIFOCalculator/ViewModels/LogViewModel.cs
+++ b/src/FIFOCalculator/ViewModels/LogViewModel.cs
@@ -12,7 +12,7 @@ using Zafiro.UI.Shell.Utils;
 
 namespace FIFOCalculator.ViewModels;
 
-[Section(icon: "fa-list", sortIndex: 2, FriendlyName = "Log")]
+[Section(icon: "fa-list", sortIndex: 3, FriendlyName = "Log")]
 public partial class LogViewModel : ViewModelBase
 {
     private readonly ReadOnlyObservableCollection<LogEntry> logEntries;

--- a/src/FIFOCalculator/Views/FiscalYearView.axaml
+++ b/src/FIFOCalculator/Views/FiscalYearView.axaml
@@ -1,0 +1,30 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:FIFOCalculator.ViewModels"
+             mc:Ignorable="d" d:DesignHeight="450"
+             x:Class="FIFOCalculator.Views.FiscalYearView"
+             x:DataType="viewModels:FiscalYearViewModel"
+             x:CompileBindings="True" Padding="10">
+    <StackPanel Spacing="8">
+        <TextBlock Text="Calculate the FIFO balance for a complete fiscal year" />
+        <TextBlock Text="Inventory from prior years is carried forward automatically"
+                   FontStyle="Italic" Opacity="0.6" />
+        <HeaderedContentControl Header="Fiscal Year">
+            <ComboBox ItemsSource="{Binding AvailableYears}"
+                      SelectedItem="{Binding SelectedYear}" />
+        </HeaderedContentControl>
+        <StackPanel DataContext="{Binding Result^}"
+                    IsVisible="{Binding ., Converter={x:Static ObjectConverters.IsNotNull}, FallbackValue=False}"
+                    Spacing="8">
+            <HeaderedContentControl Header="Gain / Loss">
+                <TextBlock HorizontalAlignment="Center" Text="{Binding SoldValue, StringFormat='{}{0:C}'}" />
+            </HeaderedContentControl>
+            <HeaderedContentControl Header="Inventory value at year end">
+                <TextBlock HorizontalAlignment="Center" Text="{Binding RemainingValue, StringFormat='{}{0:C}'}" />
+            </HeaderedContentControl>
+        </StackPanel>
+        <Button HorizontalAlignment="Center" Content="Calculate" Command="{Binding Calculate}" />
+    </StackPanel>
+</UserControl>

--- a/src/FIFOCalculator/Views/FiscalYearView.axaml.cs
+++ b/src/FIFOCalculator/Views/FiscalYearView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace FIFOCalculator.Views
+{
+    public partial class FiscalYearView : UserControl
+    {
+        public FiscalYearView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/tests/BalanceCalculatorForYearTests.cs
+++ b/tests/BalanceCalculatorForYearTests.cs
@@ -1,0 +1,195 @@
+using CSharpFunctionalExtensions.FluentAssertions;
+using FIFOCalculator.Engine;
+using FluentAssertions.Extensions;
+
+namespace TestProject1;
+
+public class BalanceCalculatorForYearTests
+{
+    [Fact]
+    public void Simple_buy_and_sell_same_year()
+    {
+        var entries = new[]
+        {
+            new Entry(1.January(2023), 10, 100),
+            new Entry(1.June(2023), -5, 150),
+        };
+
+        var sut = new BalanceCalculator();
+        var result = sut.CalculateForYear(entries, 2023);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.GainOrLoss.Should().Be(250m);
+        result.Value.RemainingInventoryValue.Should().Be(500m);
+    }
+
+    [Fact]
+    public void Cross_year_inventory_carry_forward()
+    {
+        var entries = new[]
+        {
+            new Entry(1.March(2022), 10, 100),   // buy 10 at 100 in 2022
+            new Entry(1.February(2023), -5, 150), // sell 5 at 150 in 2023
+        };
+
+        var sut = new BalanceCalculator();
+        var result = sut.CalculateForYear(entries, 2023);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.GainOrLoss.Should().Be(250m); // 5*(150-100), cost basis from 2022
+        result.Value.RemainingInventoryValue.Should().Be(500m);
+    }
+
+    [Fact]
+    public void Prior_year_sells_consume_inventory_but_not_counted_in_gain()
+    {
+        var entries = new[]
+        {
+            new Entry(1.January(2022), 10, 100),  // buy 10 at 100
+            new Entry(1.June(2022), -3, 80),       // sell 3 at 80 in 2022 (loss, not counted)
+            new Entry(1.March(2023), -4, 200),     // sell 4 at 200 in 2023
+        };
+
+        var sut = new BalanceCalculator();
+        var result = sut.CalculateForYear(entries, 2023);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.GainOrLoss.Should().Be(400m); // 4*(200-100)
+        result.Value.RemainingInventoryValue.Should().Be(300m); // 3 remaining at 100
+    }
+
+    [Fact]
+    public void No_sells_in_target_year_returns_zero_gain()
+    {
+        var entries = new[]
+        {
+            new Entry(1.January(2022), 10, 100),
+            new Entry(1.June(2022), -5, 150),
+        };
+
+        var sut = new BalanceCalculator();
+        var result = sut.CalculateForYear(entries, 2023);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.GainOrLoss.Should().Be(0m);
+        result.Value.RemainingInventoryValue.Should().Be(500m);
+    }
+
+    [Fact]
+    public void Entries_after_target_year_are_excluded()
+    {
+        var entries = new[]
+        {
+            new Entry(1.January(2023), 10, 100),
+            new Entry(1.June(2023), -5, 150),
+            new Entry(1.March(2024), -5, 200), // should be excluded
+        };
+
+        var sut = new BalanceCalculator();
+        var result = sut.CalculateForYear(entries, 2023);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.GainOrLoss.Should().Be(250m);
+        result.Value.RemainingInventoryValue.Should().Be(500m);
+    }
+
+    [Fact]
+    public void Empty_entries_returns_zero_balance()
+    {
+        var sut = new BalanceCalculator();
+        var result = sut.CalculateForYear(Enumerable.Empty<Entry>(), 2023);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.GainOrLoss.Should().Be(0m);
+        result.Value.RemainingInventoryValue.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Sell_more_than_available_fails()
+    {
+        var entries = new[]
+        {
+            new Entry(1.January(2023), 2, 100),
+            new Entry(1.February(2023), -5, 150),
+        };
+
+        var sut = new BalanceCalculator();
+        var result = sut.CalculateForYear(entries, 2023);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Fifo_order_across_years()
+    {
+        var entries = new[]
+        {
+            new Entry(1.January(2022), 5, 100),  // oldest: price 100
+            new Entry(1.June(2022), 5, 200),      // newer: price 200
+            new Entry(1.March(2023), -7, 150),    // sell 7: consumes 5@100 + 2@200
+        };
+
+        var sut = new BalanceCalculator();
+        var result = sut.CalculateForYear(entries, 2023);
+
+        result.IsSuccess.Should().BeTrue();
+        // gain = 5*(150-100) + 2*(150-200) = 250 + (-100) = 150
+        result.Value.GainOrLoss.Should().Be(150m);
+        result.Value.RemainingInventoryValue.Should().Be(600m); // 3 units at 200
+    }
+
+    [Fact]
+    public void Multiple_years_of_buys_and_sells()
+    {
+        var entries = new[]
+        {
+            new Entry(1.January(2021), 10, 50),
+            new Entry(1.June(2021), -3, 60),       // 2021 sell
+            new Entry(1.January(2022), 5, 80),
+            new Entry(1.June(2022), -4, 70),        // 2022 sell
+            new Entry(1.March(2023), -2, 100),      // 2023 sell
+        };
+
+        var sut = new BalanceCalculator();
+        var result = sut.CalculateForYear(entries, 2023);
+
+        result.IsSuccess.Should().BeTrue();
+        // After 2021: bought 10@50, sold 3@60 → 7 remaining at 50
+        // After 2022: bought 5@80, sold 4@70 → sells consume 4@50 (FIFO) → 3@50 + 5@80 remaining
+        // 2023: sell 2@100 → consumes 2@50 (FIFO) → gain = 2*(100-50) = 100
+        result.Value.GainOrLoss.Should().Be(100m);
+        // Remaining: 1@50 + 5@80 = 50 + 400 = 450
+        result.Value.RemainingInventoryValue.Should().Be(450m);
+    }
+
+    [Fact]
+    public void Real_crypto_data_for_year_2022()
+    {
+        var entries = new[]
+        {
+            new Entry(25.March(2022), 0.14495033m, 39668.76m),
+            new Entry(25.April(2022), 0.16210374m, 35471.11m),
+            new Entry(25.May(2022), 0.20720732m, 27749.98m),
+            new Entry(24.June(2022), 0.29020626m, 19813.49m),
+            new Entry(25.June(2022), -0.2463889m, 19816.14m),
+            new Entry(22.July(2022), 0.25218201m, 22764.88m),
+            new Entry(23.July(2022), -0.216239470m, 23138.11m),
+            new Entry(25.August(2022), 0.26570275m, 21640.72m),
+            new Entry(25.August(2022), -0.17348623m, 21800.53m),
+            new Entry(24.September(2022), 0.29456491m, 19520.32m),
+            new Entry(24.September(2022), -0.1942020m, 19800.20m),
+            new Entry(25.October(2022), 0.2951428m, 19482.09m),
+            new Entry(25.October(2022), -0.2121600m, 20000.00m),
+            new Entry(25.November(2022), 0.36511317m, 15748.54m),
+            new Entry(25.November(2022), -0.2585744m, 15882.00m),
+            new Entry(21.December(2022), 0.3644m, 15779.36m),
+            new Entry(22.December(2022), -0.23652997m, 15850.00m),
+        };
+
+        var sut = new BalanceCalculator();
+        var result = sut.CalculateForYear(entries, 2022);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.GainOrLoss.Should().BeNegative();
+    }
+}


### PR DESCRIPTION
## Summary

Add a new **Fiscal Year** section that calculates the FIFO balance for a complete fiscal year with proper inventory carry-forward from prior years.

### Key difference from existing Simulate section

The existing "Simulate" section filters entries to the selected year range, which **excludes buys from prior years**. This new section processes all entries from the beginning chronologically, correctly carrying forward FIFO inventory, but only counts gains/losses from sells within the target year.

### Changes

**Engine** (`BalanceCalculator.CalculateForYear`):
- Processes all entries up to the end of the target year
- Only sells within the target year contribute to gain/loss
- Prior-year sells consume inventory but don't affect the year's balance

**UI**:
- `FiscalYearViewModel` — New `[Section]` with year selector and auto-calculate
- `FiscalYearView.axaml` — Displays gain/loss and inventory value at year end
- `Models.BalanceCalculator.CalculateForYear` — Matching method with Spanish Serilog logging

**Tests** (10 new, 45 total):
- Cross-year carry-forward, FIFO ordering across years
- Prior-year sell exclusion, multi-year scenarios, real crypto data