### PR TITLE
feat: set up DotnetDeployer for CD with GitHub Releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,49 +1,51 @@
 trigger:
-  branches:
-    include: [ master ]
+  - master
+
 pr:
   branches:
-    include: [ master, "*" ]
+    include: [master, "*"]
 
 pool:
   vmImage: ubuntu-latest
 
 variables:
   - group: api-keys
+  - name: Agent.Source.Git.ShallowFetchDepth
+    value: 0
   - name: DOTNET_CLI_TELEMETRY_OPTOUT
     value: '1'
 
 steps:
-  # Checkout completo + submódulos
   - checkout: self
     submodules: true
     fetchDepth: 0
-  
-  # Install .NET 9 SDK
+
   - task: UseDotNet@2
+    displayName: 'Install .NET 10 SDK'
     inputs:
       packageType: 'sdk'
       version: '10.0.x'
-      displayName: 'Install .NET 10 SDK'
-  
-  # DotnetDeployer.Tool
+
+  # Dry run for PRs (no actual deployment)
   - pwsh: |
-      dotnet tool install --global DotnetDeployer.Tool
-      dotnetdeployer --version
-    displayName: Install DotnetDeployer.Tool
-  
-  # Empaquetado + publicación NuGet + release GitHub (real en master, dry-run en el resto)
+      dotnet tool install -g DotnetDeployer.Tool
+      dotnetdeployer --dry-run
+    displayName: 'Dry run (PRs)'
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    env:
+      GITHUB_TOKEN: $(GitHubApiKey)
+      ANDROID_KEYSTORE_BASE64: $(AndroidBase64Keystore)
+      ANDROID_SIGNING_STORE_PASS: $(AndroidSigningStorePass)
+      ANDROID_SIGNING_KEY_PASS: $(AndroidSigningKeyPass)
+
+  # Actual deployment for master branch
   - pwsh: |
-      $branch   = '$(Build.SourceBranch)'
-      $isMaster = $branch -eq 'refs/heads/master'
-      Write-Host "Branch: $branch. Is master: $isMaster"
-      
-      if ($isMaster) {
-        Write-Host 'Publishing NuGet packages'    
-        dotnetdeployer github release --github-token '$(GitHubApiKey)'
-      } else {
-        Write-Host 'NuGet dry run (no push)'
-        dotnetdeployer github release --github-token '$(GitHubApiKey)' --no-publish
-      }
-    
-    displayName: Package, Publish and Release
+      dotnet tool install -g DotnetDeployer.Tool
+      dotnetdeployer
+    displayName: Deploy
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    env:
+      GITHUB_TOKEN: $(GitHubApiKey)
+      ANDROID_KEYSTORE_BASE64: $(AndroidBase64Keystore)
+      ANDROID_SIGNING_STORE_PASS: $(AndroidSigningStorePass)
+      ANDROID_SIGNING_KEY_PASS: $(AndroidSigningKeyPass)

--- a/deployer.yaml
+++ b/deployer.yaml
@@ -1,0 +1,36 @@
+version: 1
+
+github:
+  enabled: true
+  owner: SuperJMN
+  repo: FIFOCalculator
+  tokenEnvVar: GITHUB_TOKEN
+  packages:
+    - project: src/FIFOCalculator.Android/FIFOCalculator.Android.csproj
+      formats:
+        - type: Apk
+          arch:
+            - arm64
+          signing:
+            keystore:
+              from: env
+              name: ANDROID_KEYSTORE_BASE64
+              encoding: base64
+            storePasswordEnvVar: ANDROID_SIGNING_STORE_PASS
+            keyAlias: android
+            keyPasswordEnvVar: ANDROID_SIGNING_KEY_PASS
+
+    - project: src/FIFOCalculator.Desktop/FIFOCalculator.Desktop.csproj
+      formats:
+        - type: Deb
+          arch:
+            - x64
+        - type: ExeSetup
+          arch:
+            - x64
+
+nuget:
+  enabled: false
+
+githubPages:
+  enabled: false


### PR DESCRIPTION
## Summary

Set up continuous deployment using DotnetDeployer, matching the pattern from the Pokemon repo.

### Changes

- **`deployer.yaml`** (new): Configures GitHub Releases with:
  - Android APK (arm64, signed with keystore from env)
  - Desktop: Deb (x64) + ExeSetup (x64)
  - NuGet and GitHub Pages disabled

- **`azure-pipelines.yml`** (updated): Clean two-step pipeline:
  - `--dry-run` on PRs (validates without publishing)
  - Full deploy on `master`
  - Env vars mapped from `api-keys` variable group
  - Added `Agent.Source.Git.ShallowFetchDepth: 0`

### Required Azure DevOps variables (group: `api-keys`)

| Variable | Description |
|---|---|
| `GitHubApiKey` | GitHub PAT with `repo` scope |
| `AndroidBase64Keystore` | Android keystore (base64) |
| `AndroidSigningStorePass` | Keystore password |
| `AndroidSigningKeyPass` | Signing key password |