### PR TITLE
fix: fiscal year combo empty due to Publish().RefCount() not replaying

### DIFF
--- a/src/FIFOCalculator.Desktop/FIFOCalculator.Desktop.csproj
+++ b/src/FIFOCalculator.Desktop/FIFOCalculator.Desktop.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-		<PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0-beta3" />
+		<PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/FIFOCalculator/ViewModels/EntryEditorViewModel.cs
+++ b/src/FIFOCalculator/ViewModels/EntryEditorViewModel.cs
@@ -41,7 +41,7 @@ public partial class EntryEditorViewModel : ReactiveObject
 
         DeleteSelected = ReactiveCommand.Create(() => source.Remove(SelectedEntry!), this.WhenAnyValue(x => x.SelectedEntry).Select(x => x != null));
 
-        EntriesCollection = connected
+        EntriesCollection = source.Connect()
             .AutoRefreshOnObservable(vm => vm.WhenAnyValue(x => x.When, x => x.Units, x => x.PricePerUnit))
             .Transform(x => x.ToEntry())
             .ToCollection();


### PR DESCRIPTION
## Problem

The year ComboBox in the Fiscal Year section appears empty.

## Root Cause

`EntriesCollection` in `EntryEditorViewModel` was piped through the shared `connected` observable, which uses `Publish().RefCount()`. This creates a **hot** observable that does not replay the initial DynamicData changeset to late subscribers.

`SimulationViewModel` (sortIndex 1) subscribes first during DI construction and gets the replay. `FiscalYearViewModel` (sortIndex 2) subscribes later — `Publish()` uses a regular `Subject` that doesn't replay, so `CombineLatest` never receives its first emission and `AvailableYears` stays at the initial empty list.

## Fix

Use `source.Connect()` directly for `EntriesCollection` instead of going through the shared `connected`. Each `source.Connect()` independently replays the current SourceList state to new subscribers, so all ViewModels get the data regardless of subscription order.