### PR TITLE
fix: AvailableYears combo empty due to local Publish().RefCount()

### DIFF
--- a/src/FIFOCalculator/ViewModels/FiscalYearViewModel.cs
+++ b/src/FIFOCalculator/ViewModels/FiscalYearViewModel.cs
@@ -24,14 +24,10 @@ public partial class FiscalYearViewModel : ViewModelBase
         var inputs = dataEntry.Inputs;
         var outputs = dataEntry.Outputs;
         var inputEntries = inputs.EntriesCollection
-            .Select(list => list.OrderBy(entry => entry.When).ToList())
-            .Publish()
-            .RefCount();
+            .Select(list => list.OrderBy(entry => entry.When).ToList());
 
         var outputEntries = outputs.EntriesCollection
-            .Select(list => list.OrderBy(entry => entry.When).ToList())
-            .Publish()
-            .RefCount();
+            .Select(list => list.OrderBy(entry => entry.When).ToList());
 
         entries = inputEntries
             .CombineLatest(outputEntries, (ins, outs) => ins

--- a/src/FIFOCalculator/ViewModels/SimulationViewModel.cs
+++ b/src/FIFOCalculator/ViewModels/SimulationViewModel.cs
@@ -24,14 +24,10 @@ public partial class SimulationViewModel : ViewModelBase, ISimulationViewModel
         var inputs = dataEntry.Inputs;
         var outputs = dataEntry.Outputs;
         var inputEntries = inputs.EntriesCollection
-            .Select(list => list.OrderBy(entry => entry.When).ToList())
-            .Publish()
-            .RefCount();
+            .Select(list => list.OrderBy(entry => entry.When).ToList());
 
         var outputEntries = outputs.EntriesCollection
-            .Select(list => list.OrderBy(entry => entry.When).ToList())
-            .Publish()
-            .RefCount();
+            .Select(list => list.OrderBy(entry => entry.When).ToList());
 
         entries = inputEntries
             .CombineLatest(outputEntries, (ins, outs) => ins


### PR DESCRIPTION
## Problem

The year ComboBox in Fiscal Year (and also in Simulate) appears empty.

## Root Cause

The bug has two layers, both involving `Publish().RefCount()`:

### Layer 1 (fixed in #11)
`EntriesCollection` in `EntryEditorViewModel` went through `connected` (`Publish().RefCount()`), a hot observable that doesn't replay to late subscribers.

### Layer 2 (this PR)
**Within each ViewModel**, `inputEntries` and `outputEntries` also use `Publish().RefCount()`:

```csharp
var inputEntries = inputs.EntriesCollection
    .Select(...)
    .Publish()    // ← plain Subject, no replay
    .RefCount();
```

Two OAPHs subscribe to these:
1. `entries` (1st subscriber) → triggers `RefCount` connect → DynamicData replays synchronously → `CombineLatest` gets both values ✓
2. `availableYears` (2nd subscriber) → Subject doesn't replay → `CombineLatest` never gets initial values → stays empty ✗

This affects **both** `SimulationViewModel` and `FiscalYearViewModel`. The Simulate section masked the issue because users can use the From/To date pickers directly.

## Fix

Remove `Publish().RefCount()` from both ViewModels. Each OAPH subscriber independently subscribes to `EntriesCollection`, each getting its own DynamicData replay. The overhead of separate subscriptions is negligible for this use case.